### PR TITLE
Control manipulation revamp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ## Unreleased
 ##### New
+- Docking controls are now supported.
+
+##### Fixes
+- Interaction with trim controls should now be fixed.
+- Interaction with SAS/Autopilot should now be fixed.
+
+## v0.3.0
+##### New
 - Use stock Application Launcher.
 - Control mode is persisted with command pods, probe cores, and docking ports. The mode used is determined by whichever
   part is selected with the *Control From Here* button.

--- a/Source/PlaneMode/FlightInputManipulator.cs
+++ b/Source/PlaneMode/FlightInputManipulator.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Reflection;
+
+namespace PlaneMode
+{
+    internal sealed class FlightInputManipulator
+    {
+        private static readonly BindingFlags BindingFlags;
+
+        private readonly FlightInputHandler _handler;
+
+        // ReSharper disable PrivateFieldCanBeConvertedToLocalVariable
+        private readonly FieldInfo _pitchUpField;
+        private readonly FieldInfo _pitchDownField;
+        private readonly FieldInfo _yawLeftField;
+        private readonly FieldInfo _yawRightField;
+        private readonly FieldInfo _rollLeftField;
+        private readonly FieldInfo _rollRightField;
+        private readonly FieldInfo _pitchAxisField;
+        private readonly FieldInfo _rollAxisField;
+        private readonly FieldInfo _yawAxisField;
+        private readonly FieldInfo _pitchAxisStagingField;
+        private readonly FieldInfo _pitchAxisDockingField;
+
+        private readonly UIModeKeyBindingSelector _pitchUpBinding;
+        private readonly UIModeKeyBindingSelector _pitchDownBinding;
+        private readonly UIModeKeyBindingSelector _yawLeftBinding;
+        private readonly UIModeKeyBindingSelector _yawRightBinding;
+        private readonly UIModeKeyBindingSelector _rollLeftBinding;
+        private readonly UIModeKeyBindingSelector _rollRightBinding;
+        private readonly UIModeAxisBindingSelector _pitchAxisBinding;
+        private readonly UIModeAxisBindingSelector _rollAxisBinding;
+        private readonly UIModeAxisBindingSelector _yawAxisBinding;
+
+        private readonly AxisBinding _pitchAxisStagingBinding;
+        private readonly AxisBinding _pitchAxisDockingBinding;
+
+        private readonly bool _pitchAxisStagingInverted;
+        private readonly bool _pitchAxisDockingInverted;
+        // ReSharper restore PrivateFieldCanBeConvertedToLocalVariable
+
+        public ControlMode ControlMode { get; private set; }
+
+        public bool InvertPitch { get; set; }
+
+        static FlightInputManipulator()
+        {
+            BindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
+        }
+
+        public FlightInputManipulator(FlightInputHandler handler)
+        {
+            _handler = handler;
+            ControlMode = ControlMode.Rocket;
+
+            var handlerType = typeof(FlightInputHandler);
+            var axisBindingType = typeof(UIModeAxisBindingSelector);
+
+            _pitchUpField   = handlerType.GetField("\u0010", BindingFlags);
+            _pitchDownField = handlerType.GetField("\u0011", BindingFlags);
+            _yawLeftField   = handlerType.GetField("\u0012", BindingFlags);
+            _yawRightField  = handlerType.GetField("\u0013", BindingFlags);
+            _rollLeftField  = handlerType.GetField("\u0014", BindingFlags);
+            _rollRightField = handlerType.GetField("\u0015", BindingFlags);
+            _pitchAxisField = handlerType.GetField("\u001E", BindingFlags);
+            _rollAxisField  = handlerType.GetField("\u001F", BindingFlags);
+            _yawAxisField   = handlerType.GetField("\u0020", BindingFlags);
+
+            _pitchAxisStagingField = axisBindingType.GetField("\u0001", BindingFlags);
+            _pitchAxisDockingField = axisBindingType.GetField("\u0002", BindingFlags);
+
+            // ReSharper disable PossibleNullReferenceException
+            _pitchUpBinding = (UIModeKeyBindingSelector)_pitchUpField.GetValue(_handler);
+
+            _pitchDownBinding = (UIModeKeyBindingSelector)_pitchDownField.GetValue(_handler);
+            _yawLeftBinding = (UIModeKeyBindingSelector)_yawLeftField.GetValue(_handler);
+            _yawRightBinding = (UIModeKeyBindingSelector)_yawRightField.GetValue(_handler);
+            _rollLeftBinding = (UIModeKeyBindingSelector)_rollLeftField.GetValue(_handler);
+            _rollRightBinding = (UIModeKeyBindingSelector)_rollRightField.GetValue(_handler);
+
+            _pitchAxisBinding = (UIModeAxisBindingSelector)_pitchAxisField.GetValue(_handler);
+            _rollAxisBinding = (UIModeAxisBindingSelector)_rollAxisField.GetValue(_handler);
+            _yawAxisBinding = (UIModeAxisBindingSelector)_yawAxisField.GetValue(_handler);
+
+            _pitchAxisStagingBinding = (AxisBinding)_pitchAxisStagingField.GetValue(_pitchAxisBinding);
+            _pitchAxisDockingBinding = (AxisBinding)_pitchAxisDockingField.GetValue(_pitchAxisBinding);
+
+            _pitchAxisStagingInverted = _pitchAxisStagingBinding.inverted;
+            _pitchAxisDockingInverted = _pitchAxisDockingBinding.inverted;
+            // ReSharper restore PossibleNullReferenceException
+        }
+
+        public void SetControlMode(ControlMode newControlMode)
+        {
+            if (ControlMode != newControlMode)
+            {
+                switch(newControlMode)
+                {
+                    case ControlMode.Rocket:
+                        _yawLeftField.SetValue(_handler, _yawLeftBinding);
+                        _yawRightField.SetValue(_handler, _yawRightBinding);
+                        _yawAxisField.SetValue(_handler, _yawAxisBinding);
+
+                        _rollLeftField.SetValue(_handler, _rollLeftBinding);
+                        _rollRightField.SetValue(_handler, _rollRightBinding);
+                        _rollAxisField.SetValue(_handler, _rollAxisBinding);
+
+                        _pitchUpField.SetValue(_handler, _pitchUpBinding);
+                        _pitchDownField.SetValue(_handler, _pitchDownBinding);
+
+                        _pitchAxisStagingBinding.inverted = _pitchAxisStagingInverted;
+                        _pitchAxisDockingBinding.inverted = _pitchAxisDockingInverted;
+                        break;
+                    case ControlMode.Plane:
+                        _yawLeftField.SetValue(_handler, _rollLeftBinding);
+                        _yawRightField.SetValue(_handler, _rollRightBinding);
+                        _yawAxisField.SetValue(_handler, _rollAxisBinding);
+
+                        _rollLeftField.SetValue(_handler, _yawLeftBinding);
+                        _rollRightField.SetValue(_handler, _yawRightBinding);
+                        _rollAxisField.SetValue(_handler, _yawAxisBinding);
+
+                        if (InvertPitch)
+                        {
+                            _pitchUpField.SetValue(_handler, _pitchDownBinding);
+                            _pitchDownField.SetValue(_handler, _pitchUpBinding);
+
+                            _pitchAxisStagingBinding.inverted = !_pitchAxisStagingInverted;
+                            _pitchAxisDockingBinding.inverted = !_pitchAxisDockingInverted;
+                        }
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("newControlMode");
+                }
+
+                ControlMode = newControlMode;
+            }
+        }
+    }
+}

--- a/Source/PlaneMode/IManipulator.cs
+++ b/Source/PlaneMode/IManipulator.cs
@@ -1,0 +1,10 @@
+﻿namespace PlaneMode
+{
+    public interface IManipulator
+    {
+        bool InvertPitch { get; set; }
+
+        void SetControlMode(ControlMode newControlMode);
+        void OnDestroy();
+    }
+}

--- a/Source/PlaneMode/Manipulators/FlightInputManipulator.cs
+++ b/Source/PlaneMode/Manipulators/FlightInputManipulator.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Reflection;
 
-namespace PlaneMode
+namespace PlaneMode.Manipulators
 {
-    internal sealed class FlightInputManipulator
+    internal sealed class FlightInputManipulator : IManipulator
     {
         private static readonly BindingFlags BindingFlags;
 
@@ -39,8 +39,6 @@ namespace PlaneMode
         private readonly bool _pitchAxisDockingInverted;
         // ReSharper restore PrivateFieldCanBeConvertedToLocalVariable
 
-        public ControlMode ControlMode { get; private set; }
-
         public bool InvertPitch { get; set; }
 
         static FlightInputManipulator()
@@ -51,7 +49,6 @@ namespace PlaneMode
         public FlightInputManipulator(FlightInputHandler handler)
         {
             _handler = handler;
-            ControlMode = ControlMode.Rocket;
 
             var handlerType = typeof(FlightInputHandler);
             var axisBindingType = typeof(UIModeAxisBindingSelector);
@@ -92,49 +89,49 @@ namespace PlaneMode
 
         public void SetControlMode(ControlMode newControlMode)
         {
-            if (ControlMode != newControlMode)
+            switch (newControlMode)
             {
-                switch(newControlMode)
-                {
-                    case ControlMode.Rocket:
-                        _yawLeftField.SetValue(_handler, _yawLeftBinding);
-                        _yawRightField.SetValue(_handler, _yawRightBinding);
-                        _yawAxisField.SetValue(_handler, _yawAxisBinding);
+                case ControlMode.Rocket:
+                    _yawLeftField.SetValue(_handler, _yawLeftBinding);
+                    _yawRightField.SetValue(_handler, _yawRightBinding);
+                    _yawAxisField.SetValue(_handler, _yawAxisBinding);
 
-                        _rollLeftField.SetValue(_handler, _rollLeftBinding);
-                        _rollRightField.SetValue(_handler, _rollRightBinding);
-                        _rollAxisField.SetValue(_handler, _rollAxisBinding);
+                    _rollLeftField.SetValue(_handler, _rollLeftBinding);
+                    _rollRightField.SetValue(_handler, _rollRightBinding);
+                    _rollAxisField.SetValue(_handler, _rollAxisBinding);
 
-                        _pitchUpField.SetValue(_handler, _pitchUpBinding);
-                        _pitchDownField.SetValue(_handler, _pitchDownBinding);
+                    _pitchUpField.SetValue(_handler, _pitchUpBinding);
+                    _pitchDownField.SetValue(_handler, _pitchDownBinding);
 
-                        _pitchAxisStagingBinding.inverted = _pitchAxisStagingInverted;
-                        _pitchAxisDockingBinding.inverted = _pitchAxisDockingInverted;
-                        break;
-                    case ControlMode.Plane:
-                        _yawLeftField.SetValue(_handler, _rollLeftBinding);
-                        _yawRightField.SetValue(_handler, _rollRightBinding);
-                        _yawAxisField.SetValue(_handler, _rollAxisBinding);
+                    _pitchAxisStagingBinding.inverted = _pitchAxisStagingInverted;
+                    _pitchAxisDockingBinding.inverted = _pitchAxisDockingInverted;
+                    break;
+                case ControlMode.Plane:
+                    _yawLeftField.SetValue(_handler, _rollLeftBinding);
+                    _yawRightField.SetValue(_handler, _rollRightBinding);
+                    _yawAxisField.SetValue(_handler, _rollAxisBinding);
 
-                        _rollLeftField.SetValue(_handler, _yawLeftBinding);
-                        _rollRightField.SetValue(_handler, _yawRightBinding);
-                        _rollAxisField.SetValue(_handler, _yawAxisBinding);
+                    _rollLeftField.SetValue(_handler, _yawLeftBinding);
+                    _rollRightField.SetValue(_handler, _yawRightBinding);
+                    _rollAxisField.SetValue(_handler, _yawAxisBinding);
 
-                        if (InvertPitch)
-                        {
-                            _pitchUpField.SetValue(_handler, _pitchDownBinding);
-                            _pitchDownField.SetValue(_handler, _pitchUpBinding);
+                    if (InvertPitch)
+                    {
+                        _pitchUpField.SetValue(_handler, _pitchDownBinding);
+                        _pitchDownField.SetValue(_handler, _pitchUpBinding);
 
-                            _pitchAxisStagingBinding.inverted = !_pitchAxisStagingInverted;
-                            _pitchAxisDockingBinding.inverted = !_pitchAxisDockingInverted;
-                        }
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException("newControlMode");
-                }
-
-                ControlMode = newControlMode;
+                        _pitchAxisStagingBinding.inverted = !_pitchAxisStagingInverted;
+                        _pitchAxisDockingBinding.inverted = !_pitchAxisDockingInverted;
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("newControlMode");
             }
+        }
+
+        public void OnDestroy()
+        {
+            SetControlMode(ControlMode.Rocket);
         }
     }
 }

--- a/Source/PlaneMode/Manipulators/GameSettingsManipulator.cs
+++ b/Source/PlaneMode/Manipulators/GameSettingsManipulator.cs
@@ -1,0 +1,126 @@
+﻿using System;
+
+namespace PlaneMode.Manipulators
+{
+    internal class GameSettingsManipulator : IManipulator
+    {
+        // ReSharper disable NotAccessedField.Local
+        private readonly KeyBinding _pitchUpStagingBinding;
+        private readonly KeyBinding _pitchDownStagingBinding;
+        private readonly KeyBinding _yawLeftStagingBinding;
+        private readonly KeyBinding _yawRightStagingBinding;
+        private readonly KeyBinding _rollLeftStagingBinding;
+        private readonly KeyBinding _rollRightStagingBinding;
+
+        private readonly AxisBinding _pitchAxisStagingBinding;
+        private readonly AxisBinding _rollAxisStagingBinding;
+        private readonly AxisBinding _yawAxisStagingBinding;
+
+        private readonly KeyBinding _pitchUpDockingBinding;
+        private readonly KeyBinding _pitchDownDockingBinding;
+        private readonly KeyBinding _yawLeftDockingBinding;
+        private readonly KeyBinding _yawRightDockingBinding;
+        private readonly KeyBinding _rollLeftDockingBinding;
+        private readonly KeyBinding _rollRightDockingBinding;
+        private readonly AxisBinding _pitchAxisDockingBinding;
+        private readonly AxisBinding _rollAxisDockingBinding;
+        private readonly AxisBinding _yawAxisDockingBinding;
+
+        private readonly bool _pitchAxisStagingInverted;
+        private readonly bool _pitchAxisDockingInverted;
+        // ReSharper restore NotAccessedField.Local
+
+        public bool InvertPitch { get; set; }
+
+        public GameSettingsManipulator()
+        {
+            _pitchUpStagingBinding      = GameSettings.PITCH_UP;
+            _pitchDownStagingBinding    = GameSettings.PITCH_DOWN;
+            _yawLeftStagingBinding      = GameSettings.YAW_LEFT;
+            _yawRightStagingBinding     = GameSettings.YAW_RIGHT;
+            _rollLeftStagingBinding     = GameSettings.ROLL_LEFT;
+            _rollRightStagingBinding    = GameSettings.ROLL_RIGHT;
+            _pitchAxisStagingBinding    = GameSettings.AXIS_PITCH;
+            _rollAxisStagingBinding     = GameSettings.AXIS_ROLL;
+            _yawAxisStagingBinding      = GameSettings.AXIS_YAW;
+
+            _pitchUpDockingBinding      = GameSettings.Docking_pitchUp;
+            _pitchDownDockingBinding    = GameSettings.Docking_pitchDown;
+            _yawLeftDockingBinding      = GameSettings.Docking_yawLeft;
+            _yawRightDockingBinding     = GameSettings.Docking_yawRight;
+            _rollLeftDockingBinding     = GameSettings.Docking_rollLeft;
+            _rollRightDockingBinding    = GameSettings.Docking_rollRight;
+            _pitchAxisDockingBinding    = GameSettings.axis_Docking_pitch;
+            _rollAxisDockingBinding     = GameSettings.axis_Docking_roll;
+            _yawAxisDockingBinding      = GameSettings.axis_Docking_yaw;
+
+            _pitchAxisStagingInverted = GameSettings.AXIS_PITCH.inverted;
+            _pitchAxisDockingInverted = GameSettings.axis_Docking_pitch.inverted;
+        }
+
+        public void SetControlMode(ControlMode newControlMode)
+        {
+            switch (newControlMode)
+            {
+                case ControlMode.Rocket:
+                    GameSettings.YAW_LEFT = _yawLeftStagingBinding;
+                    GameSettings.YAW_RIGHT = _yawRightStagingBinding;
+                    GameSettings.AXIS_YAW = _yawAxisStagingBinding;
+                    GameSettings.Docking_yawLeft = _yawLeftDockingBinding;
+                    GameSettings.Docking_yawRight = _yawRightDockingBinding;
+                    GameSettings.axis_Docking_yaw = _yawAxisDockingBinding;
+
+                    GameSettings.ROLL_LEFT = _rollLeftStagingBinding;
+                    GameSettings.ROLL_RIGHT = _rollRightStagingBinding;
+                    GameSettings.AXIS_ROLL = _rollAxisStagingBinding;
+                    GameSettings.Docking_rollLeft = _rollLeftDockingBinding;
+                    GameSettings.Docking_rollRight = _rollRightDockingBinding;
+                    GameSettings.axis_Docking_roll = _rollAxisDockingBinding;
+
+
+                    GameSettings.PITCH_UP = _pitchUpStagingBinding;
+                    GameSettings.PITCH_DOWN = _pitchDownStagingBinding;
+                    GameSettings.AXIS_PITCH.inverted = _pitchAxisStagingInverted;
+
+                    GameSettings.Docking_pitchUp = _pitchUpDockingBinding;
+                    GameSettings.Docking_pitchDown = _pitchDownDockingBinding;
+                    GameSettings.axis_Docking_pitch.inverted = _pitchAxisDockingInverted;
+
+                    break;
+                case ControlMode.Plane:
+                    GameSettings.YAW_LEFT = _rollLeftStagingBinding;
+                    GameSettings.YAW_RIGHT = _rollRightStagingBinding;
+                    GameSettings.AXIS_YAW = _rollAxisStagingBinding;
+                    GameSettings.Docking_yawLeft = _rollLeftDockingBinding;
+                    GameSettings.Docking_yawRight = _rollRightDockingBinding;
+                    GameSettings.axis_Docking_yaw = _rollAxisDockingBinding;
+
+                    GameSettings.ROLL_LEFT = _yawLeftStagingBinding;
+                    GameSettings.ROLL_RIGHT = _yawRightStagingBinding;
+                    GameSettings.AXIS_ROLL = _yawAxisStagingBinding;
+                    GameSettings.Docking_rollLeft = _yawLeftDockingBinding;
+                    GameSettings.Docking_rollRight = _yawRightDockingBinding;
+                    GameSettings.axis_Docking_roll = _yawAxisDockingBinding;
+
+                    if (InvertPitch)
+                    {
+                        GameSettings.PITCH_UP = _pitchDownStagingBinding;
+                        GameSettings.PITCH_DOWN = _pitchUpStagingBinding;
+                        GameSettings.AXIS_PITCH.inverted = !_pitchAxisStagingInverted;
+
+                        GameSettings.Docking_pitchUp = _pitchDownDockingBinding;
+                        GameSettings.Docking_pitchDown = _pitchUpDockingBinding;
+                        GameSettings.axis_Docking_pitch.inverted = !_pitchAxisDockingInverted;
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("newControlMode");
+            }
+        }
+
+        public void OnDestroy()
+        {
+            SetControlMode(ControlMode.Rocket);
+        }
+    }
+}

--- a/Source/PlaneMode/PlaneMode.csproj
+++ b/Source/PlaneMode/PlaneMode.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ControlMode.cs" />
+    <Compile Include="FlightInputManipulator.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="LogLevel.cs" />
     <Compile Include="ModulePlaneMode.cs" />

--- a/Source/PlaneMode/PlaneMode.csproj
+++ b/Source/PlaneMode/PlaneMode.csproj
@@ -46,7 +46,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ControlMode.cs" />
-    <Compile Include="FlightInputManipulator.cs" />
+    <Compile Include="IManipulator.cs" />
+    <Compile Include="Manipulators\FlightInputManipulator.cs" />
+    <Compile Include="Manipulators\GameSettingsManipulator.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="LogLevel.cs" />
     <Compile Include="ModulePlaneMode.cs" />


### PR DESCRIPTION
Instead of manipulating `FlightCtrlState` which has all sorts of weird interactions, manipulate the `FlightInputHandler` (through reflection) and the `GameSettings`. The effective behavior should be like if the user manually switched the control assignments; it should be fully transparent to the rest of the game and other mods.

Manipulating `GameSettings` was only necessary because the SAS code accesses `GameSettings` directly instead of using `FlightCtrlState` (ugh).