### PR TITLE
Make metanetkan's version overrides more specific

### DIFF
--- a/PlaneMode.netkan
+++ b/PlaneMode.netkan
@@ -15,77 +15,77 @@
     "x_netkan_version_edit": "^v(?<version>\\d+\\.\\d+\\.\\d+)$",
     "x_netkan_override": [
         {
-            "version": ">=0.3.0",
+            "version": [ ">=0.3.0", "<0.4.1" ],
             "override": {
                 "ksp_version_min": "0.90.0",
                 "ksp_version_max": "0.90.0"
             }
         },
         {
-            "version": ">=0.4.1",
+            "version": [ ">=0.4.1", "<1.0.0" ],
             "override": {
                 "ksp_version_min": "1.0.0",
                 "ksp_version_max": "1.0.0"
             }
         },
         {
-            "version": ">=1.0.0",
+            "version": [ ">=1.0.0", "<1.2.0" ],
             "override": {
                 "ksp_version_min": "1.0.2",
                 "ksp_version_max": "1.0.2"
             }
         },
         {
-            "version": ">=1.2.0",
+            "version": [ ">=1.2.0", "<1.3.0" ],
             "override": {
                 "ksp_version_min": "1.0.3",
                 "ksp_version_max": "1.0.3"
             }
         },
         {
-            "version": ">=1.3.0",
+            "version": [ ">=1.3.0", "<1.3.1" ],
             "override": {
                 "ksp_version_min": "1.0.4",
                 "ksp_version_max": "1.0.5"
             }
         },
         {
-            "version": ">=1.3.1",
+            "version": [ ">=1.3.1", "<1.4.0" ],
             "override": {
                 "ksp_version_min": "1.1.0",
                 "ksp_version_max": "1.1.2"
             }
         },
         {
-            "version": ">=1.4.0",
+            "version": [ ">=1.4.0", "<1.4.2" ],
             "override": {
                 "ksp_version_min": "1.1.2",
                 "ksp_version_max": "1.1.2"
             }
         },
         {
-            "version": ">=1.4.2",
+            "version": [ ">=1.4.2", "<1.4.3" ],
             "override": {
                 "ksp_version_min": "1.1.2",
                 "ksp_version_max": "1.1.3"
             }
         },
         {
-            "version": ">=1.4.3",
+            "version": [ ">=1.4.3", "<1.4.4" ],
             "override": {
                 "ksp_version_min": "1.2.0",
                 "ksp_version_max": "1.2.0"
             }
         },
         {
-            "version": ">=1.4.4",
+            "version": [ ">=1.4.4", "<1.4.5" ],
             "override": {
                 "ksp_version_min": "1.2.0",
                 "ksp_version_max": "1.2.2"
             }
         },
         {
-            "version": ">=1.4.5",
+            "version": [ ">=1.4.5" ],
             "override": {
                 "ksp_version_min": "1.3.0",
                 "ksp_version_max": "1.10.1"


### PR DESCRIPTION
Hi @dbent,

We wanted to make netkan's compatibility overrides work more like how it handles AVC so we could mix overrides with data from SpaceDock, see KSP-CKAN/CKAN#3265. Unfortunately, that broke this mod's metanetkan; it now has a minimum version of 0.90.0 instead of 1.3.0, because **all** of the overrides match the latest version, and if you apply all of those compatibility changes AVC-style, you end up with compatibility with basically all versions:

- https://github.com/KSP-CKAN/CKAN-meta/commit/f1ba89d4a90beeb2b71d80c0a11ccdf7ff39dbf5

Fortunately, the spec has an easy way to fix this! Now the overrides have both a minimum and maximum version, so only one override will match each version.

Sorry for the inconvenience!